### PR TITLE
Persist dashboard filters to url query parameters

### DIFF
--- a/apps/www/src/hooks/use-search-params-state.ts
+++ b/apps/www/src/hooks/use-search-params-state.ts
@@ -1,0 +1,32 @@
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+
+export function useSearchParamsState(key: string) {
+  const searchParams = useSearchParams()
+  const pathName = usePathname()
+  const router = useRouter()
+  const value = useMemo(() => {
+    return searchParams.get(key)
+  }, [searchParams])
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const newSearchParams = new URLSearchParams(searchParams.toString())
+      newSearchParams.set(name, value)
+      return newSearchParams.toString()
+    },
+    [searchParams]
+  )
+  const setValue = useCallback((newValue: string | null | undefined) => {
+    if (newValue === value) {
+      return
+    }
+    let updatedQueryString: string
+    if (newValue && newValue.length > 0) {
+      updatedQueryString = createQueryString(key, newValue)
+    } else {
+      updatedQueryString = createQueryString(key, '')
+    }
+    router.push(`${pathName}?${updatedQueryString}`)
+  }, [router, pathName])
+  return [value, setValue] as const
+}


### PR DESCRIPTION
Persists a JSON stringified version of the dashboard filters to url search parameters. This allows for history traversal between filters. This can also allow for clearing and visualizing filters later on